### PR TITLE
Integrate RuntimeImporter and automate code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /.xmake
 /.vscode/compile_commands.json
+/generated
+/vsxmake2022

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vscode/compile_commands.json
 /generated
 /vsxmake2022
+/.importer

--- a/data/config.json
+++ b/data/config.json
@@ -13,10 +13,10 @@
 		"profiles": {
 			"default": {
 				"export": {
-					"bpPath": "%localappdata%/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang/amethyst/mods/Amethyst-Template@dev/behavior_packs/main_bp",
+					"bpPath": "%localappdata%/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang/amethyst/mods/Amethyst-Template@0.0.0-dev/behavior_packs/main_bp",
 					"build": "standard",
 					"readOnly": false,
-					"rpPath": "%localappdata%/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang/amethyst/mods/Amethyst-Template@dev/resource_packs/main_rp",
+					"rpPath": "%localappdata%/Packages/Microsoft.MinecraftUWP_8wekyb3d8bbwe/LocalState/games/com.mojang/amethyst/mods/Amethyst-Template@0.0.0-dev/resource_packs/main_rp",
 					"target": "exact"
 				},
 				"filters": []

--- a/mod.json
+++ b/mod.json
@@ -1,6 +1,7 @@
 {
     "meta": {
         "uuid": "00000000-0000-0000-0000-000000000000",
+        "namespace": "fx_template",
         "name": "Amethyst-Template",
         "version": "0.0.0-dev",
         "author": "FrederoxDev",

--- a/mod.json
+++ b/mod.json
@@ -2,7 +2,7 @@
     "meta": {
         "uuid": "00000000-0000-0000-0000-000000000000",
         "name": "Amethyst-Template",
-        "version": "1.0.0",
+        "version": "0.0.0-dev",
         "author": "FrederoxDev",
         "dependencies": [
             {

--- a/mod.json
+++ b/mod.json
@@ -1,7 +1,15 @@
 {
     "meta": {
+        "uuid": "00000000-0000-0000-0000-000000000000",
         "name": "Amethyst-Template",
         "version": "1.0.0",
-        "author": "FrederoxDev"
+        "author": "FrederoxDev",
+        "dependencies": [
+            {
+                "dependency_uuid": "e56c3987-fd4a-4590-9923-a07fc4be7250",
+                "dependency_namespace": "amethyst",
+                "version_range": ">=2.0.0 <2.1.0"
+            }
+        ]
     }
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -35,7 +35,7 @@ else
     modFolder = path.join(
         amethystFolder,
         "mods",
-        string.format("%s@dev", mod_name)
+        string.format("%s@0.0.0-dev", mod_name)
     )
 end
 
@@ -163,7 +163,7 @@ target(mod_name)
         local include_dir = path.join(amethystApiPath, "include"):gsub("\\", "/")
         
         local gen_sym_args = {
-            "Amethyst.SymbolGenerator.exe",
+            ".importer/bin/Amethyst.SymbolGenerator.exe",
             "--input", string.format("%s", input_dir),
             "--output", string.format("%s", generated_dir),
             "--filters", "minecraft",
@@ -180,7 +180,7 @@ target(mod_name)
         os.exec(table.concat(gen_sym_args, " "))
 
         local gen_lib_args = {
-            "Amethyst.LibraryGenerator.exe",
+            ".importer/bin/Amethyst.LibraryGenerator.exe",
             "--input", string.format("%s/symbols", generated_dir),
             "--output", string.format("%s/lib", generated_dir)
         }
@@ -199,7 +199,7 @@ target(mod_name)
         os.cp(src_json, dst_json)
 
         local tweaker_args = {
-            "Amethyst.ModuleTweaker.exe",
+            ".importer/bin/Amethyst.ModuleTweaker.exe",
             "--module", target:targetfile(),
             "--symbols", string.format("%s/symbols", generated_dir)
         }

--- a/xmake.lua
+++ b/xmake.lua
@@ -54,7 +54,7 @@ set_toolchains("msvc", {asm = "nasm"})
 
 set_project(mod_name)
 
-package("RuntimeImporter")
+package("Runtime-Importer")
     set_kind("binary")
     set_homepage("https://github.com/AmethystAPI/Runtime-Importer")
     set_description("The runtime importer enables importing functions and variables from the game just by defining annotations in header files")
@@ -75,7 +75,6 @@ package("RuntimeImporter")
         local installed_version = os.isfile(installed_version_file) and io.readfile(installed_version_file) or "0.0.0"
         local should_reinstall = installed_version ~= latest_tag
         
-
         if should_reinstall then
             print("Runtime-Importer is outdated, reinstalling...")
             print("Latest version is " .. latest_tag)
@@ -115,7 +114,8 @@ package("RuntimeImporter")
     end)
 package_end()
 
-add_requires("RuntimeImporter", {system = false})
+add_requires("Runtime-Importer", {system = false})
+
 target(mod_name)
     set_kind("shared")
     add_deps("AmethystAPI", "libhat")
@@ -149,7 +149,7 @@ target(mod_name)
     )
 
     -- Deps
-    add_packages("RuntimeImporter")
+    add_packages("Runtime-Importer")
     add_packages("AmethystAPI", "libhat")
     add_links("user32", "oleaut32", "windowsapp", path.join(os.curdir(), ".importer/lib/Minecraft.Windows.lib"))
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -90,7 +90,7 @@ package("RuntimeImporter")
 
         package:addenv("PATH", bin_dir)
 
-        local generated_dir = path.join(importer_dir, "generated")
+        local generated_dir = path.join(importer_dir)
         local pch_file = path.join(generated_dir, "pch.hpp.pch")
         local should_regenerate_pch = os.exists(pch_file) == false or should_reinstall
 
@@ -151,14 +151,14 @@ target(mod_name)
     -- Deps
     add_packages("RuntimeImporter")
     add_packages("AmethystAPI", "libhat")
-    add_links("user32", "oleaut32", "windowsapp", path.join(os.curdir(), "generated/lib/Minecraft.Windows.lib"))
+    add_links("user32", "oleaut32", "windowsapp", path.join(os.curdir(), ".importer/lib/Minecraft.Windows.lib"))
 
     add_includedirs("src", {public = true})
     add_headerfiles("src/**.hpp")
 
     before_build(function (target)
         local importer_dir = path.join(os.curdir(), ".importer");
-        local generated_dir = path.join(importer_dir, "generated")
+        local generated_dir = path.join(importer_dir)
         local input_dir = path.join(amethystApiPath, "src"):gsub("\\", "/")
         local include_dir = path.join(amethystApiPath, "include"):gsub("\\", "/")
         
@@ -190,7 +190,7 @@ target(mod_name)
 
     after_build(function (target)
         local importer_dir = path.join(os.curdir(), ".importer");
-        local generated_dir = path.join(importer_dir, "generated")
+        local generated_dir = path.join(importer_dir)
         local src_json = path.join("mod.json")
         local dst_json = path.join(modFolder, "mod.json")
         if not os.isdir(modFolder) then


### PR DESCRIPTION
Added RuntimeImporter as a package and automated its installation and precompiled header generation. Updated build steps to generate symbol JSON files and Minecraft.Windows.lib before build, and to tweak the output module after build. Updated .gitignore to exclude generated and vsxmake2022 directories.